### PR TITLE
Add Cargo.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 target
-
+Cargo.lock


### PR DESCRIPTION
Latest cargo versions automatically add Cargo.lock to the gitignore of the generated project. Cargo.lock has metadata which dependends to the local build, so it's a good idea to ignore it in libraries. The exact rationale can be found in the following link: doc.crates.io/faq.html#why-do-binaries-have-cargolock-in-version-control-but-not-libraries.