### PR TITLE
Sanity checks for vector length

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+
+[package]
+name = "bitcoin-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.bitcoin]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzzer_script_1"
+path = "fuzzers/fuzzer_script_1.rs"

--- a/fuzz/fuzzers/fuzzer_script_1.rs
+++ b/fuzz/fuzzers/fuzzer_script_1.rs
@@ -1,0 +1,13 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate bitcoin;
+
+type BResult = Result<bitcoin::blockdata::script::Script, bitcoin::util::Error>;
+//type BResult = Result<bitcoin::blockdata::transaction::Transaction, bitcoin::util::Error>;
+//type BResult = Result<bitcoin::blockdata::transaction::TxIn, bitcoin::util::Error>;
+//type BResult = Result<bitcoin::blockdata::transaction::TxOut, bitcoin::util::Error>;
+//type BResult = Result<bitcoin::network::constants::Network, bitcoin::util::Error>;
+
+fuzz_target!(|data: &[u8]| {
+    let _: BResult = bitcoin::network::serialize::deserialize(data);
+});


### PR DESCRIPTION
Found a couple of panics using `cargo-fuzz` which are fixed by the following changes.