### PR TITLE
Fix vulnerabilities which found by `cargo audit`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "bitcoin"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/apoelstra/rust-bitcoin/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,6 @@ serde = "0.6"
 strason = "0.3"
 
 [dependencies.jsonrpc]
-version = "0.7" # for serde macros
+version = "0.8" # for serde macros
 default-features = false
 


### PR DESCRIPTION
Jsonrpc uses old and unsupported version of hyper.