### PR TITLE
util: add Sha256dEncoder to allow streaming data into a hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "bitcoin"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/apoelstra/rust-bitcoin/"

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -191,8 +191,11 @@ impl Transaction {
 
 impl BitcoinHash for Transaction {
     fn bitcoin_hash(&self) -> Sha256dHash {
-        use network::serialize::serialize;
-        Sha256dHash::from_data(&serialize(self).unwrap())
+        use util::hash::Sha256dEncoder;
+
+        let mut enc = Sha256dEncoder::new();
+        self.consensus_encode(&mut enc).unwrap();
+        enc.into_hash()
     }
 }
 


### PR DESCRIPTION
This is needed to for a sane BIP143 implementation. Should be exactly equivalent to
serializing data into a vector then hashing that vector for all types.