### PR TITLE
transaction: add txid() method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "bitcoin"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/apoelstra/rust-bitcoin/"


### PR DESCRIPTION
With Segwit transactions `bitcoin_hash()` is no longer sufficient to get a txid.