### PR TITLE
fixing debug output for Uint256 and Uint128

### DIFF
--- a/src/util/uint.rs
+++ b/src/util/uint.rs
@@ -312,7 +312,7 @@ macro_rules! construct_uint {
                 let &$name(ref data) = self;
                 try!(write!(f, "0x"));
                 for ch in data.iter().rev() {
-                    try!(write!(f, "{:02x}", ch));
+                    try!(write!(f, "{:016x}", ch));
                 }
                 Ok(())
             }


### PR DESCRIPTION
Debug output was misleading, displaying 0 u64 as 00 instead of 0000000000000000