### PR TITLE
Fix argument to copy_nonoverlapping in internal_macros

### DIFF
--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -88,7 +88,7 @@ macro_rules! impl_array_newtype {
                     let mut ret: $thing = mem::uninitialized();
                     copy_nonoverlapping(data.as_ptr(),
                                         ret.as_mut_ptr(),
-                                        mem::size_of::<$thing>());
+                                        $len);
                     ret
                 }
             }


### PR DESCRIPTION
This resolves a segfault due to unsafe code.